### PR TITLE
Silence compiler warnings; enable NOCHATTER

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -79,7 +79,7 @@ HFILES=misc.h strings.h line.h float.h floatrep.h tol.h command.h comment.h toke
 OTHER=README Makefile Sample.1 Sample.2 Sample.3 Sample.4 paper.ms paper.out
 MANPAGE=spiff.1
 
-CFLAGS= $(OSFLAG) $(TFLAG) $(VISFLAG)
+CFLAGS= $(OSFLAG) $(TFLAG) $(VISFLAG) -DNOCHATTER
 
 default: spiff
 
@@ -94,7 +94,7 @@ visual.o: visual.c misc.h visual.h $(MGRINCS)
 misc.o: misc.c visual.h misc.h
 
 parse.o:  parse.c misc.h line.h command.h float.h tol.h comment.h parse.h token.h flagdefs.h
-	@echo compiler may report 4 statement not reached warning messages for parse.c
+#	@echo compiler may report 4 statement not reached warning messages for parse.c
 	$(CC) $(CFLAGS) -c parse.c
 
 command.o: command.c float.h tol.h misc.h
@@ -106,7 +106,7 @@ tol.o: tol.c tol.h float.h
 output.o: output.c output.h misc.h edit.h flagdefs.h
 
 compare.o: compare.c misc.h strings.h float.h tol.h token.h line.h compare.h flagdefs.h
-	@echo compiler may report 1 statement not reached warning message for compare.c
+#	@echo compiler may report 1 statement not reached warning message for compare.c
 	$(CC) $(CFLAGS) -c compare.c
 
 float.o: float.c misc.h strings.h float.h floatrep.h

--- a/exact.c
+++ b/exact.c
@@ -11,6 +11,7 @@
 static char rcsid[]= "$Header: exact.c,v 1.1 88/09/15 11:33:55 daniel Rel $";
 #endif
 
+#include <stdio.h>
 #include "misc.h"
 #include "edit.h"
 

--- a/misc.c
+++ b/misc.c
@@ -12,6 +12,7 @@ static char rcsid[]= "$Header: misc.c,v 1.1 88/09/15 11:34:01 daniel Rel $";
 #endif
 
 #include <stdio.h>
+#include <stdlib.h>
 #include "misc.h"
 #include "visual.h"
 #include "output.h"

--- a/output.c
+++ b/output.c
@@ -12,6 +12,7 @@ static char rcsid[]= "$Header: output.c,v 1.1 88/09/15 11:33:52 daniel Rel $";
 #endif
 
 #include <stdio.h>
+#include <stdlib.h>
 
 #ifdef M_TERMINFO
 #include <curses.h>

--- a/parse.c
+++ b/parse.c
@@ -64,13 +64,10 @@ _P_alpha_clear()
 	*_P_alpha = '\0';
 }
 
-static
+static char *
 _P_in_alpha(chr)
 char chr;
 {
-#ifndef ATT
-	extern int index();
-#endif
 	/*
 	**	special case when string terminator
 	**	is handed to us
@@ -78,11 +75,7 @@ char chr;
 	if ('\0' == chr)
 		return(0);
 
-#ifdef ATT
-	return((int) strchr(_P_alpha,chr));
-#else
-	return((int) index(_P_alpha,chr));
-#endif
+	return strchr(_P_alpha,chr);
 }
 
 void

--- a/strings.h
+++ b/strings.h
@@ -6,6 +6,9 @@
 **       BELLCORE MAKES NO WARRANTY AND ACCEPTS NO LIABILITY FOR THIS PROGRAM.
 */
 
+#include <string.h>
+#include <stdio.h>
+
 #ifndef S_INCLUDED
 extern void S_wordcpy();
 extern void S_skipword();


### PR DESCRIPTION
This simple change set gives me a completely clean compile with GCC and the current Makefile - mostly by including standard headers as needed. I also have some input that triggers a segfault that I haven't been able to fix yet. I hope to get to it at some point.
